### PR TITLE
Update Firebase/GoogleSignIn dependencies and deprecated OAuthProvider credential method

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.0.0"),
-        .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "7.0.0")
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.2.0"),
+        .package(url: "https://github.com/google/GoogleSignIn-iOS.git", from: "8.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/SwiftfulFirebaseAuth/Providers/FirebaseAuthProvider.swift
+++ b/Sources/SwiftfulFirebaseAuth/Providers/FirebaseAuthProvider.swift
@@ -56,7 +56,7 @@ struct FirebaseAuthProvider: AuthProvider {
             
             // Convert Apple Auth to Firebase credential
             let credential = OAuthProvider.credential(
-                withProviderID: AuthProviderOption.apple.rawValue,
+                providerID: AuthProviderID.apple,
                 idToken: appleResponse.token,
                 rawNonce: appleResponse.nonce
             )
@@ -212,7 +212,6 @@ struct FirebaseAuthProvider: AuthProvider {
         
         return Auth.auth().currentUser
     }
-    
     
     private enum AuthError: LocalizedError {
         case noResponse


### PR DESCRIPTION
- Updated Firebase iOS SDK to version `11.2.0` and GoogleSignIn to version `8.0.0`.
- Replaced deprecated `credential(withProviderID:idToken:rawNonce:)` method with the new `credential(providerID:idToken:rawNonce:accessToken:)` method, which supports an optional `accessToken`.

These updates ensure compatibility with the latest SDK versions and resolve deprecation warnings.